### PR TITLE
Fix for breaking changes in PyGithub v2.7.0

### DIFF
--- a/update_pr.py
+++ b/update_pr.py
@@ -19,7 +19,7 @@ PAGE_SIZE_ZEPHYR = 50
 
 
 def print_rate_limit(gh, org):
-    rate_limit = gh.get_rate_limit().graphql
+    rate_limit = gh.get_rate_limit().resources.graphql
     print(f"GraphQL rate limit for {org}: {rate_limit.remaining}/{rate_limit.limit}")
 
 


### PR DESCRIPTION
Starting with PyGithub v2.7.0, Github.get_rate_limit() returns RateLimitOverview rather than RateLimit.

https://github.com/PyGithub/PyGithub/releases/tag/v2.7.0
https://pypi.org/project/PyGithub/#history

Fixes https://github.com/zephyrproject-rtos/pr-dashboard/actions/runs/16653901638