### PR TITLE
action: Make the metadata configurable

### DIFF
--- a/crunch_data.py
+++ b/crunch_data.py
@@ -75,7 +75,12 @@ def main(argv):
     prs = {}
 
     with open(INFILE, "r") as infile:
-        pr_dump = json.load(infile)
+        json_dump = json.load(infile)
+
+    metadata = json_dump["metadata"]
+    pr_dump = json_dump["prs"]
+
+    print(metadata)
 
     for pr_data in pr_dump:
         key = f"{pr_data['repository']['name']}/{pr_data['number']}"
@@ -191,6 +196,9 @@ def main(argv):
 
     if not os.path.exists(OUTDIR):
         os.mkdir(OUTDIR)
+
+    with open(f"{OUTDIR}/metadata.json", "w") as outfile:
+        json.dump(metadata, outfile, cls=Encoder, indent=4)
 
     with open(f"{OUTDIR}/users.json", "w") as outfile:
         json.dump(users, outfile, cls=Encoder, indent=4)

--- a/public/index.html
+++ b/public/index.html
@@ -70,6 +70,7 @@
         });
       })();
 
+      metadata = null;
       prs = null;
       lastDatasetUpdate = null;
 
@@ -109,7 +110,7 @@
       }
 
       function prLink(repo, pr, text) {
-        return `<a href="https://github.com/zephyrproject-rtos/${repo}/pull/${pr}">${text}</a>`;
+        return `<a href="https://github.com/${metadata.org}/${repo}/pull/${pr}">${text}</a>`;
       }
 
       function userLink(user, internal = true) {
@@ -142,7 +143,7 @@
               type: "string",
               render: (data, type, row) => {
                 if (type == "display") {
-                  docHref = `https://builds.zephyrproject.io/zephyr/pr/${row[0]}/docs/index.html`;
+                  let docHref = metadata.doc_url.replaceAll('${pr}', '${row[0]}');
                   docLink = `<a href="${docHref}" target="_blank" title="CI-built documentation">
                                <i class="bi bi-file-earmark-text"></i>
                              </a>`;
@@ -278,25 +279,25 @@
         appendData(values.previously_approved, "previously_approved");
         appendData(values.commented, "commented");
 
-        // find all unassigned zephyr PRs needing attention
+        // find all unassigned manifest repo PRs needing attention
         const unassigned = Object.keys(prs).filter((key) => {
           const prData = prs[key];
           const repo = key.split("/")[0];
           const pr = key.split("/")[1];
-          if (repo !== "zephyr") {
+          if (repo !== metadata.manifest_repo) {
             return false;
           }
           return prData.assignee_names.length === 0 && !prData.draft;
         });
         appendData(unassigned, "unassigned");
 
-        // find all zephyr PRs were only the assignee has approved (and no one else) and where no
+        // find all manifest repo PRs were only the assignee has approved (and no one else) and where no
         // one as blocked, or PRs with only one approval where author is one of the assignees
         const missingOneApproval = Object.keys(prs).filter((key) => {
           const prData = prs[key];
           const repo = key.split("/")[0];
           const pr = key.split("/")[1];
-          if (repo !== "zephyr") {
+          if (repo !== metadata.manifest_repo) {
             return false;
           }
           const assigneeIsAuthor = prData.assignee_names.includes(prData.author);
@@ -366,6 +367,14 @@
         });
       }
 
+      // Load metadata file
+      fetch("metadata.json") .then((res) => res.json()) .then((data) => {
+        metadata = data;
+        })
+        .catch((err) => {
+          console.error("Error fetching data:", err);
+        });
+
       window.addEventListener("load", () => {
         const tableConfigs = [
           { id: "author", caption: "Authored" },
@@ -375,8 +384,8 @@
           { id: "approved", caption: "Approved" },
           { id: "previously_approved", caption: "Previously Approved" },
           { id: "commented", caption: "Commented" },
-          { id: "unassigned", caption: "Unassigned [zephyr repo only]" },
-          { id: "missing_one_approval", caption: "Needs 1 More Approval [zephyr repo only]" },
+          { id: "unassigned", caption: "Unassigned [manifest repo only]" },
+          { id: "missing_one_approval", caption: "Needs 1 More Approval [manifest repo only]" },
         ];
 
         tableConfigs.forEach((config) => {

--- a/update_pr.py
+++ b/update_pr.py
@@ -42,6 +42,15 @@ def parse_args(argv):
         "-o", "--org", default="zephyrproject-rtos", help="Github organisation"
     )
     parser.add_argument(
+        "-m", "--manifest-repo", default="zephyr", help="Manifest repo"
+    )
+    parser.add_argument(
+        "-d", "--doc-url",
+        default="https://builds.zephyrproject.io/zephyr/pr/${pr}/docs/index.html",
+        help="Doc URL, use ${pr} for the PR number"
+    )
+
+    parser.add_argument(
         "-r",
         "--repos",
         default="zephyr,segger",
@@ -255,7 +264,9 @@ def main(argv):
         )
 
     print_rate_limit(gh, args.org)
-    all_prs = [pr["node"] for pr in all_prs]
+    metadata = {"org": args.org, "manifest_repo": args.manifest_repo,
+                "doc_url": args.doc_url}
+    all_prs = {"metadata": metadata, "prs": [pr["node"] for pr in all_prs]}
     save_prs(all_prs)
 
     return 0


### PR DESCRIPTION
    The URL for PRs is currently being constructed with a hardcoded org,
    "zephyrproject-rtos", so this prevents this PR Dashboard being useful in
    other orgs. Propagate the org info so that the JS can actually use it to
    construct the URL. The same applies to the manifest repo identification
    and to the doc URL, include those two up to the JS frontend.