### PR TITLE
workflow: take a screenshot of the generated page

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -14,7 +14,7 @@ defaults:
     shell: bash
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -45,8 +45,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir cache
-          python -u update_zephyr_pr.py 2>&1
-          bzip2 -c cache/data_dump.json > public/data_dump.json.bz2
+
+          # Set to false for testing with cached data.
+          if true; then
+            python -u update_zephyr_pr.py 2>&1
+            bzip2 -c cache/data_dump.json > public/data_dump.json.bz2
+          else
+            ./download_cache_data
+          fi
 
       - name: Crunch
         run: |

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -86,3 +86,33 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
+
+  screenshot:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download pages artifact
+        uses: actions/download-artifact@v5
+        with:
+          path: public
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+
+      - name: Start a local web server and take a screenshot
+        run: |
+          cd public
+          python -m http.server 8080 &
+          cd ..
+          npm install puppeteer
+          node screenshot.js
+
+      - name: Upload screenshots as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: screenshot-*.png

--- a/screenshot.js
+++ b/screenshot.js
@@ -1,0 +1,40 @@
+const puppeteer = require('puppeteer');
+const fs = require('fs');
+
+async function takeScreenshot(page, url, index) {
+    try {
+        console.log(`Navigating to ${url}...`);
+        await page.goto(url, { waitUntil: 'networkidle0' });
+
+        const filename = `screenshot-${index}.png`;
+        await page.screenshot({ path: filename, fullPage: true });
+
+        console.log(`Screenshot for ${url} saved as ${filename}`);
+    } catch (error) {
+        console.error(`Error taking screenshot for ${url}:`, error);
+    }
+}
+
+(async () => {
+    const urlsToScreenshot = [
+        'http://localhost:8080/?username=fabiobaltieri',
+        'http://localhost:8080/?username=kartben',
+    ];
+
+    const browser = await puppeteer.launch({
+        headless: 'new',
+        args: ['--no-sandbox']
+    });
+
+    const page = await browser.newPage();
+
+    await page.setViewport({ width: 1600, height: 900 });
+
+    for (const [index, url] of urlsToScreenshot.entries()) {
+        await takeScreenshot(page, url, index);
+    }
+
+    await browser.close();
+
+    console.log('All screenshots complete!');
+})();


### PR DESCRIPTION
Add a screenshot step for PR runs

Also fix the concurrency key for the runs and add an option for running on cached data, for development.