### PR TITLE
Add engagement scoring

### DIFF
--- a/crunch_data.py
+++ b/crunch_data.py
@@ -6,6 +6,9 @@
 
 from collections import defaultdict
 from dataclasses import dataclass, field, fields
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+import statistics
 import json
 import os
 import sys
@@ -13,22 +16,47 @@ import sys
 OUTDIR = "public"
 INFILE = "cache/data_dump.json"
 
+# --- SCORING CONFIGURATION ---
+ENGAGEMENT_SPEED_TARGET = int(timedelta(days=2).total_seconds())
+ENGAGEMENT_SPEED_WORST = int(timedelta(days=30).total_seconds())
+
+# Relative importance of Reliability score (number of PRs engaged vs assigned)
+# in the final Engagement Score.
+WEIGHT_RELIABILITY = 0.5
+# Relative importance of Speed score in the final Engagement Score.
+WEIGHT_SPEED = 0.5
+# -----------------------------
 
 @dataclass
 class User:
+    # set of PR keys where the user is the author
     author: set = field(default_factory=set)
+    # set of PR keys where the user is one of assignees
     assignee: set = field(default_factory=set)
+    # set of PR keys where the user is requesting changes
     blocking: set = field(default_factory=set)
+    # set of PR keys where the user has approved
     approved: set = field(default_factory=set)
+    # set of PR keys where the user has previously approved
     previously_approved: set = field(default_factory=set)
+    # set of PR keys where the user is one of the reviewers
     reviewer: set = field(default_factory=set)
+    # set of PR keys where the user has commented
     commented: set = field(default_factory=set)
+    # map of PR key to timestamp of last action by the user
     last_action: dict = field(default_factory=dict)
+    # list of engagement delays (in seconds) for the PRs the user was assigned to
+    _engaged_delays_seconds: list = field(default_factory=list)
+
+    reliability_score: float = 0.0
+    speed_score: float = 0.0
+    engagement_score: Optional[float] = None
 
     def toJSON(self):
         out = {}
         for f in fields(self):
-            out[f.name] = getattr(self, f.name)
+            if not f.name.startswith('_'):
+                out[f.name] = getattr(self, f.name)
         return out
 
 
@@ -51,6 +79,8 @@ class PR:
     ci_passes: bool = True
     ci_pending: bool = True
     trivial: bool = False
+    # Dictionary of assignee name to time (in seconds) taken to first engage after assignment
+    time_to_engage_after_assignment: dict = field(default_factory=dict)
 
     def toJSON(self):
         out = {}
@@ -68,6 +98,40 @@ class Encoder(json.JSONEncoder):
         elif isinstance(obj, PR):
             return obj.toJSON()
         return json.JSONEncoder.default(self, obj)
+
+
+def seconds_excluding_weekends(start: datetime, end: datetime) -> float:
+    """
+    Return the number of seconds between start and end,
+    ignoring any time that falls on Saturday or Sunday (GMT/UTC).
+    """
+    if end <= start:
+        return 0.0
+
+    current = start
+    total_seconds = 0.0
+
+    while current < end:
+        # If we're on a weekend, jump to next Monday 00:00 UTC.
+        if current.weekday() >= 5:  # 5 = Saturday, 6 = Sunday
+            days_to_monday = 7 - current.weekday()
+            next_monday = datetime(
+                current.year, current.month, current.day, tzinfo=current.tzinfo
+            ) + timedelta(days=days_to_monday)
+            current = max(current, next_monday)
+            continue
+
+        # We're on a weekday: consume up to either end of this day or `end`,
+        # whichever comes first.
+        next_day = datetime(
+            current.year, current.month, current.day, tzinfo=current.tzinfo
+        ) + timedelta(days=1)
+
+        segment_end = min(end, next_day)
+        total_seconds += (segment_end - current).total_seconds()
+        current = segment_end
+
+    return total_seconds
 
 
 def main(argv):
@@ -106,6 +170,46 @@ def main(argv):
         # Check for "Trivial" label
         labels = pr_data.get("labels", {}).get("nodes", [])
         pr.trivial = any(label["name"] == "Trivial" for label in labels)
+
+        assignment_times = {}
+        # Find the latest assignment time for each assignee
+        for item in pr_data.get("assignmentTimelineItems", {}).get("nodes", []):
+            if (assignee := item.get("assignee")) and (login := assignee.get("login")):
+                assignment_times[login] = max(
+                    assignment_times.get(login, ""), item["createdAt"]
+                )
+
+        actions = defaultdict(list)
+        sources = [
+            ("comments", "createdAt"),
+            ("reviews", "submittedAt"),
+            ("latestOpinionatedReviews", "submittedAt"),
+        ]
+
+        for source_key, time_field in sources:
+            for item in pr_data.get(source_key, {}).get("nodes", []):
+                author = item.get("author")
+                ts = item.get(time_field)
+                if author and ts:
+                    actions[author["login"]].append(datetime.fromisoformat(ts))
+
+        for edge in pr_data["assignees"]["edges"]:
+            user = edge["node"]["login"]
+
+            # Get string timestamp, handle Z, convert to datetime
+            start_str = assignment_times.get(user, pr.created_at).replace("Z", "+00:00")
+            assigned_at = datetime.fromisoformat(start_str)
+
+            user_acts = sorted(actions[user])
+            # Find first action that happened after assignment
+            first_act = next((t for t in user_acts if t > assigned_at), None)
+
+            if first_act:
+                delay = seconds_excluding_weekends(assigned_at, first_act)
+                users[user]._engaged_delays_seconds.append(delay)
+                pr.time_to_engage_after_assignment[user] = delay
+            else:
+                pr.time_to_engage_after_assignment[user] = None
 
         users[pr.author].author.add(key)
 
@@ -190,6 +294,49 @@ def main(argv):
     for user, data in users.items():
         print(f"{user} {data}")
 
+        total_assigned = len(data.assignee)
+        engaged_count = len(data._engaged_delays_seconds)
+
+        print(f"  total assigned: {total_assigned} engaged: {engaged_count}")
+
+        # 1. Reliability Score: Do they engage?
+        if total_assigned > 0:
+            # Percentage of assigned PRs where they actually acted
+            data.reliability_score = (engaged_count / total_assigned) * 100.0
+        else:
+            # If never assigned, reliability is technically N/A.
+            # Setting to 0 or 100 depends on philosophy.
+            # Setting to 0 ensures we don't feature inactive users.
+            data.reliability_score = 0.0
+
+        # 2. Speed Score: How fast are they (when they do engage)?
+        if engaged_count > 0:
+            metric_delay = statistics.median(data._engaged_delays_seconds)
+
+            if metric_delay <= ENGAGEMENT_SPEED_TARGET:
+                data.speed_score = 100.0
+            elif metric_delay >= ENGAGEMENT_SPEED_WORST:
+                data.speed_score = 0.0
+            else:
+                # Linear Interpolation (Sliding Scale)
+                # As delay increases from Target -> Limit, Score decreases 100 -> 0
+                total_range = ENGAGEMENT_SPEED_WORST - ENGAGEMENT_SPEED_TARGET
+                excess_delay = metric_delay - ENGAGEMENT_SPEED_TARGET
+                penalty_percent = (excess_delay / total_range) * 100.0
+                data.speed_score = 100.0 - penalty_percent
+        else:
+            data.speed_score = 0.0
+
+        # 3. Final Weighted Score
+        if total_assigned > 0 or engaged_count > 0:
+            final = (WEIGHT_RELIABILITY * data.reliability_score) + (
+                WEIGHT_SPEED * data.speed_score
+            )
+            data.engagement_score = round(final, 1)
+        else:
+            # User has no activity and no assignments
+            data.engagement_score = None
+
     print("")
     for pr, data in prs.items():
         print(f"PR {pr} {data}")
@@ -205,6 +352,36 @@ def main(argv):
 
     with open(f"{OUTDIR}/prs.json", "w") as outfile:
         json.dump(prs, outfile, cls=Encoder, indent=4)
+
+    print("\nEngagement Scores:")
+    headers = ["User", "Engagement Score", "Assigned PRs"]
+    rows = []
+    for user, data in users.items():
+        if data.engagement_score is not None:
+            rows.append((user, data.engagement_score, len(data.assignee)))
+
+    # Sort by engagement score descending
+    rows.sort(key=lambda x: x[1], reverse=True)
+
+    if rows:
+        # Calculate column widths
+        col_widths = [len(h) for h in headers]
+        for row in rows:
+            col_widths[0] = max(col_widths[0], len(str(row[0])))
+            col_widths[1] = max(col_widths[1], len(f"{row[1]:.1f}"))
+            col_widths[2] = max(col_widths[2], len(str(row[2])))
+
+        # Create format string
+        fmt = "| " + " | ".join(f"{{:<{w}}}" for w in col_widths) + " |"
+        separator = "+-" + "-+-".join("-" * w for w in col_widths) + "-+"
+
+        print(separator)
+        print(fmt.format(*headers))
+        print(separator)
+        for row in rows:
+            print(fmt.format(row[0], f"{row[1]:.1f}", row[2]))
+        print(separator)
+
 
 
 if __name__ == "__main__":

--- a/public/index.html
+++ b/public/index.html
@@ -134,7 +134,7 @@
         return priorityA === priorityB ? a.localeCompare(b) : priorityA - priorityB;
       }
 
-      function createDataTable(id, caption) {
+      function createDataTable(id, caption, showTimeToEngage = false) {
         new DataTable($(`#${id}`), {
           columns: [
             {
@@ -147,7 +147,7 @@
                   docLink = `<a href="${docHref}" target="_blank" title="CI-built documentation">
                                <i class="bi bi-file-earmark-text"></i>
                              </a>`;
-                  return docLink + " " + prLink(row[13], data, data);
+                  return docLink + " " + prLink(row[14], data, data);
                 } else {
                   return data;
                 }
@@ -159,21 +159,21 @@
               responsivePriority: 2,
               render: (data, type, row) => {
                 if (type == "display") {
-                  const link = prLink(row[13], row[0], data);
+                  const link = prLink(row[14], row[0], data);
                   // add orange "R" badge if rebasing is needed, and a red "CI" badge if CI fails
                   let badges = "";
-                  if (!row[8] || row[9]) {
+                  if (!row[9] || row[10]) {
                     // broken CI is red, pending CI is blue
-                    badge_color = row[9] ? "info" : "danger";
+                    badge_color = row[10] ? "info" : "danger";
                     badges += `<span class="badge bg-${badge_color}" title="CI failed / pending">CI</span> `;
                   }
-                  if (row[10]) {
+                  if (row[11]) {
                     badges += `<span class="badge bg-warning text-dark" title="Rebase needed">R</span> `;
                   }
-                  if (row[11]) {
+                  if (row[12]) {
                     badges = `<span class="badge bg-secondary" title="Unknown status">?</span> `;
                   }
-                  if (row[12]) {
+                  if (row[13]) {
                     badges += `<span class="badge bg-success" title="Trivial">T</span> `;
                   }
 
@@ -211,6 +211,24 @@
               responsivePriority: 5,
             },
             { title: "Base", responsivePriority: 200 },
+            ...(showTimeToEngage ? [{
+              title: '<span title="Time to Engage: How long it took for the assignee to first engage with this PR after assignment">TTE</span>',
+              render: (data, type, row) => {
+                const urlParams = new URLSearchParams(window.location.search);
+                const currentUser = urlParams.get("username");
+                const userDelay = (currentUser && data && data[currentUser]) ? data[currentUser] : null;
+
+                if (type === "display") {
+                  if (userDelay !== null) {
+                    return moment.duration(userDelay, "seconds").humanize();
+                  }
+                  return "N/A";
+                }
+                // For sorting, return the raw numeric value (or Infinity for N/A to sort last)
+                return userDelay !== null ? userDelay : Infinity;
+              },
+              responsivePriority: 7,
+            }] : []),
             {
               title: "Updated",
               render: (data, type, row) => (type == "display" ? timeSince(data) : data),
@@ -223,7 +241,7 @@
             { title: "Trivial", visible: false },
             { title: "Repo", visible: false },
           ],
-          order: [[6, "desc"]], // Show most recently updated PRs first
+          order: [[showTimeToEngage ? 7 : 6, "desc"]], // Show most recently updated PRs first
           paging: false,
           info: false,
           responsive: {
@@ -231,7 +249,7 @@
           },
           stateSave: true,
           createdRow: function (row, data, index) {
-            if (data[7] === true) {
+            if (data[showTimeToEngage ? 8 : 7] === true) {
               $(row).addClass("draft");
             }
           },
@@ -253,6 +271,7 @@
             prData.assignee_names,
             prData.reviewer_names,
             `${repo}/${prData.base}`,
+            prData.time_to_engage_after_assignment || {},
             prData.updated_at,
             prData.draft,
             prData.ci_passes,
@@ -265,7 +284,7 @@
 
           dataTable.row.add(row);
         }
-        dataTable.columns.adjust().draw().responsive.recalc();
+        dataTable.columns.adjust().draw(false).responsive.recalc();
         oldCaption = dataTable.caption().split(" (")[0];
         dataTable.caption(oldCaption + ` (${dataTable.rows().count()})`);
       }
@@ -330,9 +349,10 @@
             stats.assignee.length,
             stats.approved.length,
             stats.blocking.length,
+            stats.engagement_score,
           ]);
         });
-        leaderboard.columns.adjust().draw().responsive.recalc();
+        leaderboard.columns.adjust().draw(false).responsive.recalc();
       }
 
       function refreshData() {
@@ -362,7 +382,7 @@
               });
           } else {
             // raw data hasn't changed but redraw table to update "since" columns
-            $(".prs").DataTable().rows().invalidate().draw();
+            $(".prs").DataTable().rows().invalidate().draw(false);
           }
         });
       }
@@ -371,7 +391,7 @@
         const tableConfigs = [
           { id: "author", caption: "Authored" },
           { id: "requested_changes", caption: "Requested changes" },
-          { id: "assignee", caption: "Assigned" },
+          { id: "assignee", caption: "Assigned", showTimeToEngage: true },
           { id: "reviewer", caption: "Reviewer" },
           { id: "approved", caption: "Approved" },
           { id: "previously_approved", caption: "Previously Approved" },
@@ -381,7 +401,7 @@
         ];
 
         tableConfigs.forEach((config) => {
-          createDataTable(config.id, config.caption);
+          createDataTable(config.id, config.caption, config.showTimeToEngage);
         });
 
         // create Leaderboard table (user - assigned PRs - approved PRs - blocked PRs)
@@ -392,6 +412,18 @@
             { title: "Assigned", responsivePriority: 3 },
             { title: "Approved", responsivePriority: 4 },
             { title: "Requested changes", responsivePriority: 5 },
+            {
+              title: "Engagement Score",
+              responsivePriority: 6,
+              render: (data, type, row) => {
+                if (type === "display") {
+                  return data !== null
+                    ? data.toFixed(0)
+                    : "N/A";
+                }
+                return data === null ? -1 : data;
+              },
+            },
           ],
           paging: true,
           info: false,

--- a/update_pr.py
+++ b/update_pr.py
@@ -125,6 +125,29 @@ query (
               endCursor
             }
           }
+          reviews(first: 50) {
+            nodes {
+              author {
+                login
+              }
+              submittedAt
+            }
+          }
+          assignmentTimelineItems: timelineItems(
+            first: 50
+            itemTypes: [ASSIGNED_EVENT]
+          ) {
+            nodes {
+              ... on AssignedEvent {
+                createdAt
+                assignee {
+                  ... on User {
+                    login
+                  }
+                }
+              }
+            }
+          }
           dismissedReviewsTimelineItems: timelineItems(
             first: 20
             itemTypes: [REVIEW_DISMISSED_EVENT]


### PR DESCRIPTION
The engagement score combines two metrics with equal weighting (50% each - we can discuss tweaking all the parameters of course)

1. Reliability Score (0-100%): Measures the percentage of assigned PRs where the reviewer actually engaged (commented, reviewed, ...) versus total PRs assigned to them.

2. Speed Score (0-100%): Evaluates how quickly reviewers respond after being assigned. Uses median response time across all their assignments, score ranging from:
   - 100 points: Response within 2 days
   - 0 points: Response takes 30+ days

Response times exclude weekends / only counts business days (GMT)

Final engagement score = (0.5 × reliability) + (0.5 × speed)