### PR TITLE
Extend dashboard with multiuser filtering

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -70,9 +70,9 @@
         });
       })();
 
-      metadata = null;
-      prs = null;
-      lastDatasetUpdate = null;
+      let metadata = null;
+      let prs = null;
+      let lastDatasetUpdate = null;
       let selectedUsers = []; // Currently selected usernames for filtering
       let users = {}; // User stats loaded from users.json
 

--- a/public/index.html
+++ b/public/index.html
@@ -73,19 +73,33 @@
       metadata = null;
       prs = null;
       lastDatasetUpdate = null;
+      let selectedUsers = []; // Currently selected usernames for filtering
+      let users = {}; // User stats loaded from users.json
 
-      function saveGHUser(name) {
-        localStorage.setItem("gh_user", name);
+      // Store array of usernames in localStorage
+      function saveSelectedUsers(usernames) {
+        localStorage.setItem("gh_users", JSON.stringify(usernames));
       }
 
-      function loadGHUser() {
-        return localStorage.getItem("gh_user");
+      // Load array of usernames from localStorage
+      function loadSelectedUsers() {
+        const saved = localStorage.getItem("gh_users");
+        if (saved) {
+          try {
+            return JSON.parse(saved);
+          } catch (e) {
+            console.error("Failed to parse saved users", e);
+            return [];
+          }
+        }
+        return [];
       }
 
-      function populateAutocomplete(users) {
+      function populateAutocomplete(users, excludeList = []) {
         const datalist = document.getElementById("usernames");
         datalist.innerHTML = "";
         Object.keys(users)
+          .filter((username) => !excludeList.includes(username))
           .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
           .forEach((username) => {
             const option = document.createElement("option");
@@ -310,16 +324,49 @@
         appendData(missingOneApproval, "missing_one_approval");
       }
 
+      function mergeUserStats(usernames, usersData) {
+        const statKeys = [
+          "author",
+          "blocking",
+          "assignee",
+          "reviewer",
+          "approved",
+          "previously_approved",
+          "commented",
+        ];
+        const mergedStats = Object.fromEntries(
+          statKeys.map((key) => [key, new Set()])
+        );
+
+        // Aggregate PRs from all selected users
+        for (const username of usernames) {
+          const userStats = usersData[username];
+          if (!userStats) continue;
+
+          // Add this user's PRs to each stat category
+          for (const key of statKeys) {
+            const prList = userStats[key];
+            if (prList?.length) {
+              prList.forEach((pr) => mergedStats[key].add(pr));
+            }
+          }
+        }
+
+        // Convert deduped sets back to arrays
+        return Object.fromEntries(
+          statKeys.map((key) => [key, Array.from(mergedStats[key])])
+        );
+      }
+
       function processData(data) {
         prs = data[0];
-        const users = data[1];
-        const urlParams = new URLSearchParams(window.location.search);
-        const username = urlParams.get("username");
+        users = data[1];
 
-        if (username && users[username]) {
-          appendUser(users[username]);
+        if (selectedUsers.length > 0) {
+          const merged = mergeUserStats(selectedUsers, users);
+          appendUser(merged);
         }
-        populateAutocomplete(users);
+        populateAutocomplete(users, selectedUsers);
 
         const leaderboard = $("#leaderboard").DataTable();
         leaderboard.clear();
@@ -333,6 +380,95 @@
           ]);
         });
         leaderboard.columns.adjust().draw().responsive.recalc();
+      }
+
+      function updateUserChips() {
+        // Maximum number of visible chips before collapsing into "+N more" popover
+        const maxVisibleChips = 3;
+        const visible = selectedUsers.slice(0, maxVisibleChips);
+        const hidden = selectedUsers.slice(maxVisibleChips);
+
+        // Clear existing chips and repopulate
+        const $container = $("#gh-username-chips");
+        $container.empty();
+
+        visible.forEach((username) => {
+          $container.append(
+            $(`<span class="gh-username-chip">
+                <span>${username}</span>
+                <button type="button" class="gh-username-chip-remove"
+                        data-user="${username}" aria-label="Remove ${username}">
+                  <i class="bi bi-x"></i>
+                </button>
+              </span>`)
+          );
+        });
+
+        if (hidden.length > 0) {
+          const hiddenHtml = hidden
+            .map(
+              (u) =>
+                `<span class="gh-username-chip">
+                  <span>${u}</span>
+                  <button type="button" class="gh-username-chip-remove"
+                          data-user="${u}" aria-label="Remove ${u}">
+                    <i class="bi bi-x"></i>
+                  </button>
+                </span>`
+            )
+            .join("");
+
+          const $moreBtn = $(
+            `<button type="button" class="gh-more-chip"
+                     data-bs-toggle="popover" data-bs-html="true"
+                     title="More users" aria-label="Show ${hidden.length} more users">
+              +${hidden.length} more
+            </button>`
+          );
+          $container.append($moreBtn);
+
+          new bootstrap.Popover($moreBtn[0], {
+            content: `<div class="d-flex flex-wrap gap-2">${hiddenHtml}</div>`,
+            html: true,
+            sanitize: false,
+            trigger: "focus"
+          });
+        }
+
+        // Show/hide clear button based on selected users
+        $("#gh-clear-users").toggleClass("d-none", selectedUsers.length === 0);
+
+        // Update autocomplete to exclude selected users
+        populateAutocomplete(users, selectedUsers);
+      }
+
+      function addUser(username) {
+        if (!users[username]) {
+          return false;
+        }
+        if (!selectedUsers.includes(username)) {
+          selectedUsers.push(username);
+          updateUserChips();
+          updateURL();
+        }
+        return true;
+      }
+
+      function removeUser(username) {
+        selectedUsers = selectedUsers.filter((u) => u !== username);
+        updateUserChips();
+        updateURL(selectedUsers.length === 0);
+      }
+
+      function updateURL(forceClear = false) {
+        if (selectedUsers.length > 0) {
+          const userQuery = selectedUsers.join(",");
+          saveSelectedUsers(selectedUsers);
+          window.location.href = `?username=${userQuery}`;
+        } else if (forceClear) {
+          saveSelectedUsers([]);
+          window.location.href = `?`;
+        }
       }
 
       function refreshData() {
@@ -366,6 +502,31 @@
           }
         });
       }
+
+      function handleUserRemoval(e) {
+        const $button = $(e.target).closest(".gh-username-chip-remove");
+        if ($button.length === 0) return false;
+        e.preventDefault();
+        const username = $button.data("user");
+        if (username) removeUser(username);
+        return true;
+      }
+
+      function handleUserClearAll(e) {
+        const $clearBtn = $(e.target).closest("#gh-clear-users");
+        if ($clearBtn.length === 0) return false;
+        e.preventDefault();
+        selectedUsers = [];
+        updateUserChips();
+        updateURL(true);
+        return true;
+      }
+
+      // Delegate click handlers
+      $(document).on("click", (e) => {
+        if (handleUserRemoval(e)) return;
+        if (handleUserClearAll(e)) return;
+      });
 
       function initTable() {
         const tableConfigs = [
@@ -405,24 +566,58 @@
         }).caption("<i class='bi-trophy'></i> Leaderboard");
 
         const ghUsernameInput = document.getElementById("gh-username-input");
-        ghUsernameInput.value =
-          new URLSearchParams(window.location.search).get("username") || loadGHUser();
-        history.replaceState(null, "", `?username=${ghUsernameInput.value}`);
+        const urlParams = new URLSearchParams(window.location.search);
+        const usernameParam = urlParams.get("username");
 
-        // ENTER key pressed
+        if (usernameParam) {
+          selectedUsers = usernameParam
+            .split(",")
+            .map(u => u.trim())
+            .filter(u => u);
+          saveSelectedUsers(selectedUsers);
+        } else {
+          const savedUsers = loadSelectedUsers();
+          if (savedUsers.length > 0) {
+            selectedUsers = savedUsers;
+            updateURL();
+            return; // Exit early since updateURL() reloads the page
+          }
+        }
+
+        updateUserChips();
+        ghUsernameInput.placeholder = "Enter GitHub username";
+
+        // ENTER key pressed or Backspace on empty to remove last
         ghUsernameInput.addEventListener("keydown", (event) => {
           if (event.key === "Enter") {
+            event.preventDefault();
             const username = ghUsernameInput.value.trim();
-            saveGHUser(username);
-            window.location.href = `?username=${username}`;
+            if (username) {
+              if (addUser(username)) {
+                ghUsernameInput.value = "";
+              } else {
+                ghUsernameInput.classList.add("is-invalid");
+                setTimeout(() => ghUsernameInput.classList.remove("is-invalid"), 1500);
+              }
+            }
+          }
+
+          if (event.key === "Backspace" &&
+              ghUsernameInput.value === "" &&
+              selectedUsers.length) {
+            event.preventDefault();
+            removeUser(selectedUsers[selectedUsers.length - 1]);
           }
         });
 
         // autocomplete entry selection
         ghUsernameInput.addEventListener("change", () => {
           const username = ghUsernameInput.value.trim();
-          saveGHUser(username);
-          window.location.href = `?username=${username}`;
+          if (username && users[username]) {
+            if (addUser(username)) {
+              ghUsernameInput.value = "";
+            }
+          }
         });
 
         refreshData();
@@ -448,17 +643,28 @@
       <div class="spinner-border text-primary" role="status"></div>
     </div>
     <nav id="navbar" class="navbar bg-body-tertiary px-3 mb-3 sticky-top">
-      <div class="container-fluid">
-        <form class="d-flex">
-          <input
-            class="form-controls"
-            id="gh-username-input"
-            type="text"
-            placeholder="Enter GitHub username"
-            list="usernames" />
+      <div class="container-fluid gap-2">
+        <form class="d-flex gap-2">
+          <div class="gh-username-container">
+            <span id="gh-username-chips"></span>
+            <input
+              class="form-controls"
+              id="gh-username-input"
+              type="text"
+              placeholder="Enter GitHub username"
+              autocomplete="off"
+              list="usernames" />
+            <button
+              type="button"
+              id="gh-clear-users"
+              class="gh-clear-btn d-none"
+              title="Clear all users">
+              <i class="bi bi-x-lg"></i>
+            </button>
+          </div>
           <datalist id="usernames"></datalist>
         </form>
-        <ul class="nav nav-pills">
+        <ul class="nav nav-pills flex-wrap">
           <li class="nav-item">
             <a class="nav-link" href="#author">Authored</a>
           </li>
@@ -477,7 +683,6 @@
           <li class="nav-item">
             <a class="nav-link" href="#previously_approved">Previously Approved</a>
           </li>
-
           <li class="nav-item">
             <a class="nav-link" href="#commented">Commented</a>
           </li>

--- a/public/index.html
+++ b/public/index.html
@@ -76,6 +76,16 @@
       let selectedUsers = []; // Currently selected usernames for filtering
       let users = {}; // User stats loaded from users.json
 
+      const tablesConfig = [
+        { key: "author", tableId: "author", caption: "Authored" },
+        { key: "blocking", tableId: "requested_changes", caption: "Requested changes" },
+        { key: "assignee", tableId: "assignee", caption: "Assigned" },
+        { key: "reviewer", tableId: "reviewer", caption: "Reviewer" },
+        { key: "approved", tableId: "approved", caption: "Approved" },
+        { key: "previously_approved", tableId: "previously_approved", caption: "Previously Approved" },
+        { key: "commented", tableId: "commented", caption: "Commented" },
+      ];
+
       // Store array of usernames in localStorage
       function saveSelectedUsers(usernames) {
         localStorage.setItem("gh_users", JSON.stringify(usernames));
@@ -285,13 +295,9 @@
       }
 
       function appendUser(values) {
-        appendData(values.author, "author");
-        appendData(values.blocking, "requested_changes");
-        appendData(values.assignee, "assignee");
-        appendData(values.reviewer, "reviewer");
-        appendData(values.approved, "approved");
-        appendData(values.previously_approved, "previously_approved");
-        appendData(values.commented, "commented");
+        tablesConfig.forEach((config) => {
+          appendData(values[config.key], config.tableId);
+        });
 
         // find all unassigned manifest repo PRs needing attention
         const unassigned = Object.keys(prs).filter((key) => {
@@ -325,15 +331,7 @@
       }
 
       function mergeUserStats(usernames, usersData) {
-        const statKeys = [
-          "author",
-          "blocking",
-          "assignee",
-          "reviewer",
-          "approved",
-          "previously_approved",
-          "commented",
-        ];
+        const statKeys = tablesConfig.map((c) => c.key);
         const mergedStats = Object.fromEntries(
           statKeys.map((key) => [key, new Set()])
         );
@@ -529,19 +527,14 @@
       });
 
       function initTable() {
-        const tableConfigs = [
-          { id: "author", caption: "Authored" },
-          { id: "requested_changes", caption: "Requested changes" },
-          { id: "assignee", caption: "Assigned" },
-          { id: "reviewer", caption: "Reviewer" },
-          { id: "approved", caption: "Approved" },
-          { id: "previously_approved", caption: "Previously Approved" },
-          { id: "commented", caption: "Commented" },
+        const allTablesConfig = [
+          ...tablesConfig.map((c) => ({ id: c.tableId, caption: c.caption })),
+          // Additional tables for various types of PRs that need attention
           { id: "unassigned", caption: `Unassigned [${metadata.manifest_repo} repo only]` },
           { id: "missing_one_approval", caption: `Needs 1 More Approval [${metadata.manifest_repo} repo only]` },
         ];
 
-        tableConfigs.forEach((config) => {
+        allTablesConfig.forEach((config) => {
           createDataTable(config.id, config.caption);
         });
 

--- a/public/style.css
+++ b/public/style.css
@@ -8,25 +8,148 @@ a:hover {
   text-decoration: underline;
 }
 
-#gh-username-input {
-  width: 200px;
+.gh-username-container {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
   padding: 10px 15px;
-  font-size: 16px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.375rem;
+  background-color: var(--bs-body-bg);
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
   transition: border-color 0.3s, box-shadow 0.3s;
-  outline: none;
+  min-height: 44px;
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 60%;
+  max-width: 100%;
+  overflow: hidden;
 }
 
-#gh-username-input:focus {
+.gh-username-container:focus-within {
   border-color: #333f67;
-  box-shadow: 0px 0px 8px rgba(51, 63, 103, 0.5);
+  box-shadow: 0 0 0.5rem rgba(51, 63, 103, 0.5);
+}
+
+#gh-username-chips {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  overflow: hidden;
+  max-width: 480px;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.gh-username-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.125rem 0.25rem 0.5rem;
+  background-color: var(--bs-secondary);
+  color: var(--bs-white);
+  border-radius: 1rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+  max-width: 145px;
+  overflow: visible;
+  flex: 0 1 auto;
+}
+
+.gh-username-chip > :first-child {
+  max-width: 90px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.gh-username-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  background-color: transparent;
+  color: currentColor;
+  border: none;
+  padding: 0 0.0625rem;
+  line-height: 1;
+  flex: 0 0 auto;
+  cursor: pointer;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+}
+
+.gh-username-chip-remove:hover {
+  opacity: 1;
+}
+
+.gh-more-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.5rem;
+  background-color: var(--bs-secondary);
+  border: 1px solid var(--bs-secondary);
+  color: var(--bs-white);
+  border-radius: 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  flex: 0 0 auto;
+  cursor: pointer;
+  transition: box-shadow 0.15s;
+}
+
+.gh-more-chip:focus {
+  outline: none;
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
+}
+
+.gh-clear-btn {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background-color: transparent;
+  color: var(--bs-secondary);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.gh-clear-btn:hover {
+  color: var(--bs-secondary);
+}
+
+#gh-username-input {
+  flex: 1 1 100px;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  outline: none;
+  padding: 0 2rem 0 0;
+  color: var(--bs-body-color);
 }
 
 #gh-username-input::placeholder {
-  color: #aaa;
+  color: var(--bs-secondary);
+  opacity: 0.6;
   font-style: italic;
+}
+
+#gh-username-input.is-invalid {
+  color: var(--bs-form-invalid-color);
 }
 
 #scroll-area {
@@ -83,4 +206,8 @@ a.blocked {
 .dt-search {
   position: absolute;
   right: 2em;
+}
+
+.popover-header {
+  background-color: var(--bs-light);
 }

--- a/screenshot.js
+++ b/screenshot.js
@@ -19,6 +19,7 @@ async function takeScreenshot(page, url, index) {
     const urlsToScreenshot = [
         'http://localhost:8080/?username=fabiobaltieri',
         'http://localhost:8080/?username=kartben',
+        'http://localhost:8080/?username=fabiobaltieri,kartben,mmahadevan108,manuargue',
     ];
 
     const browser = await puppeteer.launch({


### PR DESCRIPTION
Extend dashboard with multiuser filtering to track PRs across teams and areas. Maintain existing single-user workflow compatibility.

- Support comma-separated usernames in URL parameters (`?username=user1,user2`)
- Aggregate PR data across selected users
- Implement removable user chips with `+N more` popover for overflow
- Add keyboard shortcuts (`Enter` to add, `Backspace` to remove last user)

<img width="1899" height="358" alt="image" src="https://github.com/user-attachments/assets/76e602b0-148a-411a-abd3-ad41ca24d5e1" />
