### PR TITLE
update GraphQL query to include statusCheckRollup

### DIFF
--- a/crunch_data.py
+++ b/crunch_data.py
@@ -97,11 +97,10 @@ def main(argv):
         pr.needs_rebase = pr_data["mergeable"] == "CONFLICTING"
         pr.unknown_mergeable_status = pr_data["mergeable"] == "UNKNOWN"
 
-        commits_nodes = pr_data["commits"]["nodes"]
-        if commits_nodes:
-            status_check = commits_nodes[0]["commit"]["statusCheckRollup"]
-            pr.ci_passes = status_check and status_check.get("state") == "SUCCESS"
-            pr.ci_pending = status_check and status_check.get("state") == "PENDING"
+        status_check = pr_data.get("statusCheckRollup")
+        if status_check:
+            pr.ci_passes = status_check.get("state") == "SUCCESS"
+            pr.ci_pending = status_check.get("state") == "PENDING"
 
         # Check for "Trivial" label
         labels = pr_data.get("labels", {}).get("nodes", [])

--- a/update_pr.py
+++ b/update_pr.py
@@ -93,6 +93,9 @@ query (
           createdAt
           updatedAt
           mergeable
+          statusCheckRollup {
+            state
+          }
           author {
             login
           }
@@ -160,15 +163,6 @@ query (
             pageInfo {
               hasNextPage
               endCursor
-            }
-          }
-          commits(last: 1) {
-            nodes {
-              commit {
-                statusCheckRollup {
-                  state
-                }
-              }
             }
           }
           labels(first: 20) {


### PR DESCRIPTION
No need to get the statusCheckRollup from the latest commit, just get it from the PR itself.

Doesn't seem to speed anything up nor cost any less tokens tho :) 